### PR TITLE
deviseの設定とタスクのCRUD機能を実装 #17

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,5 +63,10 @@ end
 gem "slim-rails"
 gem "devise"
 gem "devise-i18n"
+gem 'devise-i18n-views'
 gem 'letter_opener'
 gem 'dotenv-rails'
+gem "tailwindcss-rails"
+gem "tailwindcss-ruby", "3.4.17"
+gem 'rails-i18n', '~> 7.0.0'
+gem "enum_help"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,12 +115,15 @@ GEM
     devise-i18n (1.13.0)
       devise (>= 4.9.0)
       rails-i18n
+    devise-i18n-views (0.3.7)
     dotenv (3.1.8)
     dotenv-rails (3.1.8)
       dotenv (= 3.1.8)
       railties (>= 6.1)
     drb (2.2.3)
     ed25519 (1.4.0)
+    enum_help (0.0.19)
+      activesupport (>= 3.0.0)
     erb (5.0.1)
     erubi (1.13.1)
     globalid (1.2.1)
@@ -336,6 +339,14 @@ GEM
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringio (3.1.7)
+    tailwindcss-rails (3.3.2)
+      railties (>= 7.0.0)
+      tailwindcss-ruby (~> 3.0)
+    tailwindcss-ruby (3.4.17-aarch64-linux)
+    tailwindcss-ruby (3.4.17-arm-linux)
+    tailwindcss-ruby (3.4.17-arm64-darwin)
+    tailwindcss-ruby (3.4.17-x86_64-darwin)
+    tailwindcss-ruby (3.4.17-x86_64-linux)
     temple (0.10.3)
     thor (1.3.2)
     thruster (0.1.13)
@@ -388,7 +399,9 @@ DEPENDENCIES
   debug
   devise
   devise-i18n
+  devise-i18n-views
   dotenv-rails
+  enum_help
   jbuilder
   jsbundling-rails
   kamal
@@ -398,10 +411,13 @@ DEPENDENCIES
   propshaft
   puma (>= 5.0)
   rails (~> 7.2.1)
+  rails-i18n (~> 7.0.0)
   rubocop-rails-omakase
   selenium-webdriver
   slim-rails
   stimulus-rails
+  tailwindcss-rails
+  tailwindcss-ruby (= 3.4.17)
   thruster
   turbo-rails
   tzinfo-data

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,2 +1,2 @@
-web: env RUBY_DEBUG_OPEN=true bin/rails server
 js: yarn build --watch
+css: bin/rails tailwindcss:watch

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -1,0 +1,13 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+/*
+
+@layer components {
+  .btn-primary {
+    @apply py-2 px-4 bg-blue-200;
+  }
+}
+
+*/

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,0 +1,69 @@
+class TasksController < ApplicationController
+  before_action :set_task, only: %i[ show edit update destroy ]
+
+  # GET /tasks or /tasks.json
+  def index
+    @tasks = current_user.tasks
+  end
+
+  # GET /tasks/1 or /tasks/1.json
+  def show; end
+
+  # GET /tasks/new
+  def new
+    @task = current_user.tasks.build
+  end
+
+  # GET /tasks/1/edit
+  def edit
+  end
+
+  # POST /tasks or /tasks.json
+  def create
+    @task = current_user.tasks.build(task_params)
+
+    respond_to do |format|
+      if @task.save
+        format.html { redirect_to @task, notice: "Task was successfully created." }
+        format.json { render :show, status: :created, location: @task }
+      else
+        format.html { render :new, status: :unprocessable_entity }
+        format.json { render json: @task.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /tasks/1 or /tasks/1.json
+  def update
+    respond_to do |format|
+      if @task.update(task_params)
+        format.html { redirect_to @task, notice: "Task was successfully updated." }
+        format.json { render :show, status: :ok, location: @task }
+      else
+        format.html { render :edit, status: :unprocessable_entity }
+        format.json { render json: @task.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /tasks/1 or /tasks/1.json
+  def destroy
+    @task.destroy!
+
+    respond_to do |format|
+      format.html { redirect_to tasks_path, status: :see_other, notice: "Task was successfully destroyed." }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_task
+      @task = current_user.tasks.find(params[:id])
+    end
+
+    # Only allow a list of trusted parameters through.
+    def task_params
+      params.require(:task).permit(:title, :memo, :estimated_time, :is_done, :recurrence_interval, :priority_level, :parent_task_id, :position)
+    end
+end

--- a/app/helpers/tasks_helper.rb
+++ b/app/helpers/tasks_helper.rb
@@ -1,0 +1,2 @@
+module TasksHelper
+end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,3 @@
 // Entry point for the build script in your package.json
-import "@hotwired/turbo-rails"
+// import "@hotwired/turbo-rails"
 import "./controllers"

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,0 +1,14 @@
+class Task < ApplicationRecord
+  enum is_done: { not_started: 0, closed: 1 }
+
+  belongs_to :user
+  belongs_to :parent_task, class_name: 'Task', optional: true
+
+  validates :title, presence: true, length: { minimum: 3, maximum: 20 }
+  # validates :memo, allow_blank: true, length: { minimum: 3, maximum: 100 }
+  # validates :estimated_time, allow_blank: true, numericality: true
+
+  def is_done_text
+    I18n.t("activerecord.attributes.task.is_done_values.#{is_done}")
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,8 @@
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+
+  has_many :tasks, dependent: :destroy
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable,
          :confirmable

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,6 +1,6 @@
-<h2>Resend confirmation instructions</h2>
+<h2><%= t('.resend_confirmation_instructions') %></h2>
 
-<%= form_for(resource, as: resource_name, url: user_confirmation_path, html: { method: :post }) do |f| %>
+<%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">
@@ -9,7 +9,7 @@
   </div>
 
   <div class="actions">
-    <%= f.submit "Resend confirmation instructions" %>
+    <%= f.submit t('.resend_confirmation_instructions') %>
   </div>
 <% end %>
 

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,5 +1,5 @@
-<p>Welcome <%= @email %>!</p>
+<p><%= t('.greeting', recipient: @email) %></p>
 
-<p>You can confirm your account email through the link below:</p>
+<p><%= t('.instruction') %></p>
 
-<p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>
+<p><%= link_to t('.action'), confirmation_url(@resource, confirmation_token: @token) %></p>

--- a/app/views/devise/mailer/email_changed.html.erb
+++ b/app/views/devise/mailer/email_changed.html.erb
@@ -1,7 +1,7 @@
-<p>Hello <%= @email %>!</p>
+<p><%= t('.greeting', recipient: @email) %></p>
 
 <% if @resource.try(:unconfirmed_email?) %>
-  <p>We're contacting you to notify you that your email is being changed to <%= @resource.unconfirmed_email %>.</p>
+  <p><%= t('.message_unconfirmed', email: @resource.unconfirmed_email) %></p>
 <% else %>
-  <p>We're contacting you to notify you that your email has been changed to <%= @resource.email %>.</p>
+  <p><%= t('.message', email: @resource.email) %></p>
 <% end %>

--- a/app/views/devise/mailer/password_change.html.erb
+++ b/app/views/devise/mailer/password_change.html.erb
@@ -1,3 +1,3 @@
-<p>Hello <%= @resource.email %>!</p>
+<p><%= t('.greeting', recipient: @resource.email) %></p>
 
-<p>We're contacting you to notify you that your password has been changed.</p>
+<p><%= t('.message') %></p>

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,8 +1,8 @@
-<p>Hello <%= @resource.email %>!</p>
+<p><%= t('.greeting', recipient: @resource.email) %></p>
 
-<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+<p><%= t('.instruction') %></p>
 
-<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
+<p><%= link_to t('.action'), edit_password_url(@resource, reset_password_token: @token) %></p>
 
-<p>If you didn't request this, please ignore this email.</p>
-<p>Your password won't change until you access the link above and create a new one.</p>
+<p><%= t('.instruction_2') %></p>
+<p><%= t('.instruction_3') %></p>

--- a/app/views/devise/mailer/unlock_instructions.html.erb
+++ b/app/views/devise/mailer/unlock_instructions.html.erb
@@ -1,7 +1,7 @@
-<p>Hello <%= @resource.email %>!</p>
+<p><%= t('.greeting', recipient: @resource.email) %></p>
 
-<p>Your account has been locked due to an excessive number of unsuccessful sign in attempts.</p>
+<p><%= t('.message') %></p>
 
-<p>Click the link below to unlock your account:</p>
+<p><%= t('.instruction') %></p>
 
-<p><%= link_to 'Unlock my account', unlock_url(@resource, unlock_token: @token) %></p>
+<p><%= link_to t('.action'), unlock_url(@resource, unlock_token: @token) %></p>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,24 +1,24 @@
-<h2>Change your password</h2>
+<h2><%= t('.change_your_password') %></h2>
 
-<%= form_for(resource, as: resource_name, url: user_password_path, html: { method: :put }) do |f| %>
+<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
   <%= f.hidden_field :reset_password_token %>
 
   <div class="field">
-    <%= f.label :password, "New password" %><br />
+    <%= f.label :password, t('.new_password') %><br />
     <% if @minimum_password_length %>
-      <em>(<%= @minimum_password_length %> characters minimum)</em><br />
+      <em><%= t('devise.shared.minimum_password_length', count: @minimum_password_length) %></em><br />
     <% end %>
     <%= f.password_field :password, autofocus: true, autocomplete: "new-password" %>
   </div>
 
   <div class="field">
-    <%= f.label :password_confirmation, "Confirm new password" %><br />
+    <%= f.label :password_confirmation, t('.confirm_new_password') %><br />
     <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
   </div>
 
   <div class="actions">
-    <%= f.submit "Change my password" %>
+    <%= f.submit t('.change_my_password') %>
   </div>
 <% end %>
 

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,6 +1,6 @@
-<h2>Forgot your password?</h2>
+<h2><%= t('.forgot_your_password') %></h2>
 
-<%= form_for(resource, as: resource_name, url: user_password_path, html: { method: :post }) do |f| %>
+<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">
@@ -9,7 +9,7 @@
   </div>
 
   <div class="actions">
-    <%= f.submit "Send me reset password instructions" %>
+    <%= f.submit t('.send_me_reset_password_instructions') %>
   </div>
 <% end %>
 

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,6 +1,6 @@
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
+<h2><%= t('.title', resource: devise_i18n_fix_model_name_case(resource.model_name.human, i18n_key: 'registrations.edit.title')) %></h2>
 
-<%= form_for(resource, as: resource_name, url: user_registration_path, html: { method: :put }) do |f| %>
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">
@@ -9,15 +9,15 @@
   </div>
 
   <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+    <div><%= t('.currently_waiting_confirmation_for_email', email: resource.unconfirmed_email) %></div>
   <% end %>
 
   <div class="field">
-    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
+    <%= f.label :password %> <i>(<%= t('.leave_blank_if_you_don_t_want_to_change_it') %>)</i><br />
     <%= f.password_field :password, autocomplete: "new-password" %>
     <% if @minimum_password_length %>
       <br />
-      <em><%= @minimum_password_length %> characters minimum</em>
+      <em><%= t('devise.shared.minimum_password_length', count: @minimum_password_length) %></em>
     <% end %>
   </div>
 
@@ -27,17 +27,17 @@
   </div>
 
   <div class="field">
-    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
+    <%= f.label :current_password %> <i>(<%= t('.we_need_your_current_password_to_confirm_your_changes') %>)</i><br />
     <%= f.password_field :current_password, autocomplete: "current-password" %>
   </div>
 
   <div class="actions">
-    <%= f.submit "Update" %>
+    <%= f.submit t('.update') %>
   </div>
 <% end %>
 
-<h3>Cancel my account</h3>
+<h3><%= t('.cancel_my_account') %></h3>
 
-<div>Unhappy? <%= button_to "Cancel my account", user_registration_path, data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete %></div>
+<div><%= t('.unhappy') %> <%= button_to t('.cancel_my_account'), registration_path(resource_name), data: { confirm: t('.are_you_sure'), turbo_confirm: t('.are_you_sure') }, method: :delete %></div>
 
-<%= link_to "Back", :back %>
+<%= link_to t('devise.shared.links.back'), :back %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,6 +1,6 @@
-<h2>Sign up</h2>
+<h2><%= t('.sign_up') %></h2>
 
-<%= form_for(resource, as: resource_name, url: user_registration_path) do |f| %>
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">
@@ -11,7 +11,7 @@
   <div class="field">
     <%= f.label :password %>
     <% if @minimum_password_length %>
-    <em>(<%= @minimum_password_length %> characters minimum)</em>
+    <em><%= t('devise.shared.minimum_password_length', count: @minimum_password_length) %></em>
     <% end %><br />
     <%= f.password_field :password, autocomplete: "new-password" %>
   </div>
@@ -22,7 +22,7 @@
   </div>
 
   <div class="actions">
-    <%= f.submit "Sign up" %>
+    <%= f.submit t('.sign_up') %>
   </div>
 <% end %>
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,6 +1,6 @@
-<h2>Log in</h2>
+<h2><%= t('.sign_in') %></h2>
 
-<%= form_for(resource, as: resource_name, url: user_session_path) do |f| %>
+<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
   <div class="field">
     <%= f.label :email %><br />
     <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
@@ -19,7 +19,7 @@
   <% end %>
 
   <div class="actions">
-    <%= f.submit "Log in" %>
+    <%= f.submit t('.sign_in') %>
   </div>
 <% end %>
 

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -3,7 +3,7 @@
     <h2>
       <%= I18n.t("errors.messages.not_saved",
                  count: resource.errors.count,
-                 resource: resource.class.model_name.human.downcase)
+                 resource: devise_i18n_fix_model_name_case(resource.model_name.human, i18n_key: 'errors.messages.not_saved'))
        %>
     </h2>
     <ul>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,25 +1,25 @@
 <%- if controller_name != 'sessions' %>
-  <%= link_to "Log in", new_user_session_path %><br />
+  <%= link_to t(".sign_in"), new_session_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "Sign up", new_user_registration_path %><br />
+  <%= link_to t(".sign_up"), new_registration_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to "Forgot your password?", new_user_password_path %><br />
+  <%= link_to t(".forgot_your_password"), new_password_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-  <%= link_to "Didn't receive confirmation instructions?", new_user_confirmation_path %><br />
+  <%= link_to t('.didn_t_receive_confirmation_instructions'), new_confirmation_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
-  <%= link_to "Didn't receive unlock instructions?", new_user_unlock_path %><br />
+  <%= link_to t('.didn_t_receive_unlock_instructions'), new_unlock_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.omniauthable? %>
   <%- resource_class.omniauth_providers.each do |provider| %>
-    <%#= button_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), data: { turbo: false } %><br />
+    <%= button_to t('.sign_in_with_provider', provider: OmniAuth::Utils.camelize(provider)), omniauth_authorize_path(resource_name, provider), data: { turbo: false } %><br />
   <% end %>
 <% end %>

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -1,6 +1,6 @@
-<h2>Resend unlock instructions</h2>
+<h2><%= t('.resend_unlock_instructions') %></h2>
 
-<%= form_for(resource, as: resource_name, url: unlock_user_path, html: { method: :post }) do |f| %>
+<%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">
@@ -9,7 +9,7 @@
   </div>
 
   <div class="actions">
-    <%= f.submit "Resend unlock instructions" %>
+    <%= f.submit t('.resend_unlock_instructions') %>
   </div>
 <% end %>
 

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -1,4 +1,6 @@
-h1 Home#index
-p Find me in app/views/home/index.html.slim
+h1.text-4xl.text-green-700.font-semibold.underline Home#index
+
+p
+    'Find me in app/views/home/index.html.slim'
 | ようこそ
 = link_to 'logout', main_app.destroy_user_session_path, method: :delete

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,11 +18,14 @@
     <link rel="apple-touch-icon" href="/icon.png">
 
     <%# Includes all stylesheet files in app/assets/stylesheets %>
+    <%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %>
     <%= stylesheet_link_tag :app, "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
   </head>
 
   <body>
-    <%= yield %>
+    <main class="container mx-auto mt-28 px-5 flex">
+      <%= yield %>
+    </main>
   </body>
 </html>

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -1,0 +1,65 @@
+<%= form_with(model: task, class: "contents") do |form| %>
+  <% if task.errors.any? %>
+    <div id="error_explanation" class="bg-red-50 text-red-500 px-3 py-2 font-medium rounded-md mt-3">
+      <h2><%= pluralize(task.errors.count, "error") %> prohibited this task from being saved:</h2>
+
+      <ul class="list-disc ml-6">
+        <% task.errors.each do |error| %>
+          <li><%= error.full_message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="my-5">
+    <%= form.label :title %>
+    <%= form.text_field :title, class: ["block shadow rounded-md border outline-none px-3 py-2 mt-2 w-full", {"border-gray-400 focus:outline-blue-600": task.errors[:title].none?, "border-red-400 focus:outline-red-600": task.errors[:title].any?}] %>
+  </div>
+<% 
+=begin
+%>
+  <div class="my-5">
+    <%= form.label :memo %>
+    <%= form.text_area :memo, rows: 4, class: ["block shadow rounded-md border outline-none px-3 py-2 mt-2 w-full", {"border-gray-400 focus:outline-blue-600": task.errors[:memo].none?, "border-red-400 focus:outline-red-600": task.errors[:memo].any?}] %>
+  </div>
+
+  <div class="my-5">
+    <%= form.label :estimated_time %>
+    <%= form.number_field :estimated_time, class: ["block shadow rounded-md border outline-none px-3 py-2 mt-2 w-full", {"border-gray-400 focus:outline-blue-600": task.errors[:estimated_time].none?, "border-red-400 focus:outline-red-600": task.errors[:estimated_time].any?}] %>
+  </div>
+<% 
+=end
+%>
+  <div class="my-5">
+    <%= form.label :is_done %>
+    <%= form.select :is_done, Task.is_dones.keys, class: ["block shadow rounded-md border outline-none px-3 py-2 mt-2 w-full", {"border-gray-400 focus:outline-blue-600": task.errors[:is_done].none?, "border-red-400 focus:outline-red-600": task.errors[:is_done].any?}] %>
+  </div>
+<% 
+=begin
+%>
+  <div class="my-5">
+    <%= form.label :recurrence_interval %>
+    <%= form.text_field :recurrence_interval, class: ["block shadow rounded-md border outline-none px-3 py-2 mt-2 w-full", {"border-gray-400 focus:outline-blue-600": task.errors[:recurrence_interval].none?, "border-red-400 focus:outline-red-600": task.errors[:recurrence_interval].any?}] %>
+  </div>
+
+  <div class="my-5">
+    <%= form.label :priority_level %>
+    <%= form.number_field :priority_level, class: ["block shadow rounded-md border outline-none px-3 py-2 mt-2 w-full", {"border-gray-400 focus:outline-blue-600": task.errors[:priority_level].none?, "border-red-400 focus:outline-red-600": task.errors[:priority_level].any?}] %>
+  </div>
+
+  <div class="my-5">
+    <%= form.label :parent_task_id %>
+    <%= form.number_field :parent_task_id, class: ["block shadow rounded-md border outline-none px-3 py-2 mt-2 w-full", {"border-gray-400 focus:outline-blue-600": task.errors[:parent_task_id].none?, "border-red-400 focus:outline-red-600": task.errors[:parent_task_id].any?}] %>
+  </div>
+  <div class="my-5">
+    <%= form.label :position %>
+    <%= form.number_field :position, class: ["block shadow rounded-md border outline-none px-3 py-2 mt-2 w-full", {"border-gray-400 focus:outline-blue-600": task.errors[:position].none?, "border-red-400 focus:outline-red-600": task.errors[:position].any?}] %>
+  </div>
+
+<% 
+=end
+%>
+  <div class="inline">
+    <%= form.submit class: "rounded-md px-3.5 py-2.5 bg-blue-600 hover:bg-blue-500 text-white inline-block font-medium cursor-pointer" %>
+  </div>
+<% end %>

--- a/app/views/tasks/_task.html.erb
+++ b/app/views/tasks/_task.html.erb
@@ -1,0 +1,38 @@
+<div id="<%= dom_id task %>">
+  <p class="my-5">
+    <strong class="block font-medium mb-1"><%= t("activerecord.attributes.task.title") %></strong>
+    <%= task.title %>
+  </p>
+  <p class="my-5">
+    <strong class="block font-medium mb-1"><%= t("activerecord.attributes.task.memo") %></strong>
+    <%= task.memo %>
+  </p>
+  <p class="my-5">
+    <strong class="block font-medium mb-1"><%= t("activerecord.attributes.task.estimated_time") %>:</strong>
+    <%= task.estimated_time %>
+  </p>
+  <p class="my-5">
+    <strong class="block font-medium mb-1"><%= Task.human_attribute_name(:is_done) %>:</strong>
+    <%= task.is_done_i18n %>
+  </p>
+  <p class="my-5">
+    <strong class="block font-medium mb-1"><%= t("activerecord.attributes.task.recurrence_interval") %>:</strong>
+    <%= task.recurrence_interval %>
+  </p>
+  <p class="my-5">
+    <strong class="block font-medium mb-1"><%= t("activerecord.attributes.task.priority_level") %>:</strong>
+    <%= task.priority_level %>
+  </p>
+  <p class="my-5">
+    <strong class="block font-medium mb-1"><%= t("activerecord.attributes.task.user") %>:</strong>
+    <%= task.user_id %>
+  </p>
+  <p class="my-5">
+    <strong class="block font-medium mb-1"><%= t("activerecord.attributes.task.parent_task") %>:</strong>
+    <%= task.parent_task_id %>
+  </p>
+  <p class="my-5">
+    <strong class="block font-medium mb-1"><%= t("activerecord.attributes.task.position") %>:</strong>
+    <%= task.position %>
+  </p>
+</div>

--- a/app/views/tasks/_task.json.jbuilder
+++ b/app/views/tasks/_task.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! task, :id, :title, :memo, :estimated_time, :is_done, :recurrence_interval, :priority_level, :user_id, :parent_task_id, :position, :created_at, :updated_at
+json.url task_url(task, format: :json)

--- a/app/views/tasks/edit.html.erb
+++ b/app/views/tasks/edit.html.erb
@@ -1,0 +1,10 @@
+<% content_for :title, "Editing task" %>
+
+<div class="md:w-2/3 w-full">
+  <h1 class="font-bold text-4xl">Editing task</h1>
+
+  <%= render "form", task: @task %>
+
+  <%= link_to "Show this task", @task, class: "ml-2 rounded-md px-3.5 py-2.5 bg-gray-100 hover:bg-gray-50 inline-block font-medium" %>
+  <%= link_to "Back to tasks", tasks_path, class: "ml-2 rounded-md px-3.5 py-2.5 bg-gray-100 hover:bg-gray-50 inline-block font-medium" %>
+</div>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,0 +1,25 @@
+<% content_for :title, "Tasks" %>
+
+<div class="w-full">
+  <% if notice.present? %>
+    <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-md inline-block" id="notice"><%= notice %></p>
+  <% end %>
+
+  <div class="flex justify-between items-center">
+    <h1 class="font-bold text-4xl">タスク</h1>
+    <%= link_to t("views.tasks.new_task"), new_task_path, class: "rounded-md px-3.5 py-2.5 bg-blue-600 hover:bg-blue-500 text-white block font-medium" %>
+  </div>
+
+  <div id="tasks" class="min-w-full">
+    <% if @tasks.any? %>
+      <% @tasks.each do |task| %>
+        <%= render task %>
+        <p>
+          <%= link_to t("views.tasks.show_this_task"), task, class: "ml-2 rounded-md px-3.5 py-2.5 bg-gray-100 hover:bg-gray-50 inline-block font-medium" %>
+        </p>
+      <% end %>
+    <% else %>
+      <p class="text-center my-10">No tasks found.</p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/tasks/index.json.jbuilder
+++ b/app/views/tasks/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @tasks, partial: "tasks/task", as: :task

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -1,0 +1,9 @@
+<% content_for :title, "New task" %>
+
+<div class="md:w-2/3 w-full">
+  <h1 class="font-bold text-4xl">New task</h1>
+
+  <%= render "form", task: @task %>
+
+  <%= link_to t("views.tasks.back_to_tasks"), tasks_path, class: "ml-2 rounded-md px-3.5 py-2.5 bg-gray-100 hover:bg-gray-50 inline-block font-medium" %>
+</div>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -1,0 +1,17 @@
+<% content_for :title, "Showing task" %>
+
+<div class="md:w-2/3 w-full">
+  <% if notice.present? %>
+    <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-md inline-block" id="notice"><%= notice %></p>
+  <% end %>
+
+  <h1 class="font-bold text-4xl">Showing task</h1>
+
+  <%= render @task %>
+
+  <%= link_to "Edit this task", edit_task_path(@task), class: "mt-2 rounded-md px-3.5 py-2.5 bg-gray-100 hover:bg-gray-50 inline-block font-medium" %>
+  <%= link_to "Back to tasks", tasks_path, class: "ml-2 rounded-md px-3.5 py-2.5 bg-gray-100 hover:bg-gray-50 inline-block font-medium" %>
+  <div class="inline-block ml-2">
+    <%= button_to "Destroy this task", @task, method: :delete, class: "mt-2 rounded-md px-3.5 py-2.5 text-white bg-red-600 hover:bg-red-500 font-medium" %>
+  </div>
+</div>

--- a/app/views/tasks/show.json.jbuilder
+++ b/app/views/tasks/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "tasks/task", task: @task

--- a/bin/dev
+++ b/bin/dev
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-if gem list --no-installed --exact --silent foreman; then
+if ! gem list foreman -i --silent; then
   echo "Installing foreman..."
   gem install foreman
 fi
@@ -8,4 +8,9 @@ fi
 # Default to port 3000 if not specified
 export PORT="${PORT:-3000}"
 
-exec foreman start -f Procfile.dev --env /dev/null "$@"
+# Let the debug gem allow remote connections,
+# but avoid loading until `debugger` is called
+export RUBY_DEBUG_OPEN="true"
+export RUBY_DEBUG_LAZY="true"
+
+exec foreman start -f Procfile.dev "$@"

--- a/config/application.rb
+++ b/config/application.rb
@@ -6,6 +6,8 @@ require "rails/all"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
+require 'enum_help'
+
 module TaskSplitTodo
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
@@ -21,7 +23,8 @@ module TaskSplitTodo
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    # config.time_zone = "Central Time (US & Canada)"
+    config.time_zone = "Tokyo"
+    config.i18n.default_locale = :ja
     # config.eager_load_paths << Rails.root.join("extras")
   end
 end

--- a/config/locales/activerecord.ja.yml
+++ b/config/locales/activerecord.ja.yml
@@ -1,0 +1,15 @@
+ja:
+  activerecord:
+    models:
+      task: タスク
+    attributes:
+      task:
+        title: タイトル
+        memo: メモ
+        is_done: 状態
+        estimated_time: 所要時間
+        recurrence_interval: 繰り返し期間
+        priority_level: 優先順位
+        user_id: ユーザーID
+        parent_task_id: 親タスクID
+        position: 並び順

--- a/config/locales/enum_ja.yml
+++ b/config/locales/enum_ja.yml
@@ -1,0 +1,8 @@
+ja:
+  activerecord:
+    attributes:
+      task:
+        is_done: 状態
+        is_done_values:
+          not_started: 未着手
+          closed: 完了

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,207 @@
+---
+ja:
+  activerecord:
+    errors:
+      messages:
+        record_invalid: 'バリデーションに失敗しました: %{errors}'
+        restrict_dependent_destroy:
+          has_one: "%{record}が存在しているので削除できません"
+          has_many: "%{record}が存在しているので削除できません"
+  date:
+    abbr_day_names:
+    - 日
+    - 月
+    - 火
+    - 水
+    - 木
+    - 金
+    - 土
+    abbr_month_names:
+    - 
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    day_names:
+    - 日曜日
+    - 月曜日
+    - 火曜日
+    - 水曜日
+    - 木曜日
+    - 金曜日
+    - 土曜日
+    formats:
+      default: "%Y/%m/%d"
+      long: "%Y年%m月%d日(%a)"
+      short: "%m/%d"
+    month_names:
+    - 
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    order:
+    - :year
+    - :month
+    - :day
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: 約1時間
+        other: 約%{count}時間
+      about_x_months:
+        one: 約1ヶ月
+        other: 約%{count}ヶ月
+      about_x_years:
+        one: 約1年
+        other: 約%{count}年
+      almost_x_years:
+        one: 1年弱
+        other: "%{count}年弱"
+      half_a_minute: 30秒前後
+      less_than_x_seconds:
+        one: 1秒以内
+        other: "%{count}秒未満"
+      less_than_x_minutes:
+        one: 1分以内
+        other: "%{count}分未満"
+      over_x_years:
+        one: 1年以上
+        other: "%{count}年以上"
+      x_seconds:
+        one: 1秒
+        other: "%{count}秒"
+      x_minutes:
+        one: 1分
+        other: "%{count}分"
+      x_days:
+        one: 1日
+        other: "%{count}日"
+      x_months:
+        one: 1ヶ月
+        other: "%{count}ヶ月"
+      x_years:
+        one: 1年
+        other: "%{count}年"
+    prompts:
+      second: 秒
+      minute: 分
+      hour: 時
+      day: 日
+      month: 月
+      year: 年
+  errors:
+    format: "%{attribute}%{message}"
+    messages:
+      accepted: を受諾してください
+      blank: を入力してください
+      confirmation: と%{attribute}の入力が一致しません
+      empty: を入力してください
+      equal_to: は%{count}にしてください
+      even: は偶数にしてください
+      exclusion: は予約されています
+      greater_than: は%{count}より大きい値にしてください
+      greater_than_or_equal_to: は%{count}以上の値にしてください
+      inclusion: は一覧にありません
+      invalid: は不正な値です
+      less_than: は%{count}より小さい値にしてください
+      less_than_or_equal_to: は%{count}以下の値にしてください
+      model_invalid: 'バリデーションに失敗しました: %{errors}'
+      not_a_number: は数値で入力してください
+      not_an_integer: は整数で入力してください
+      odd: は奇数にしてください
+      other_than: は%{count}以外の値にしてください
+      present: は入力しないでください
+      required: を入力してください
+      taken: はすでに存在します
+      too_long: は%{count}文字以内で入力してください
+      too_short: は%{count}文字以上で入力してください
+      wrong_length: は%{count}文字で入力してください
+    template:
+      body: 次の項目を確認してください
+      header:
+        one: "%{model}にエラーが発生しました"
+        other: "%{model}に%{count}個のエラーが発生しました"
+  helpers:
+    select:
+      prompt: 選択してください
+    submit:
+      create: 登録する
+      submit: 保存する
+      update: 更新する
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%n%u"
+        precision: 0
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: 円
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: 十億
+          million: 百万
+          quadrillion: 千兆
+          thousand: 千
+          trillion: 兆
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n%u"
+        units:
+          byte: バイト
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: "、"
+      two_words_connector: "、"
+      words_connector: "、"
+  time:
+    am: 午前
+    formats:
+      default: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
+      long: "%Y/%m/%d %H:%M"
+      short: "%m/%d %H:%M"
+    pm: 午後

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -1,0 +1,48 @@
+#参考
+ja:
+  views:
+    tasks:
+      back_to_tasks: タスク一覧に戻る
+      new_task: 新規タスク
+      show_this_task: タスク詳細
+  helpers:
+    submit:
+      create: 登録
+      submit: 保存
+      update: 更新
+    label:
+      email: メールアドレス
+      password: パスワード
+  user_sessions:
+    new:
+      title: ログイン
+      login: ログイン
+      to_register_page: 登録ページへ
+      password_forget: パスワードをお忘れの方はこちら
+  users:
+    new:
+      title: ユーザー登録
+      to_login_page: ログインページへ
+  header:
+    login: ログイン
+    logout: ログアウト
+    board: 掲示板
+    board_index: 掲示板一覧
+    create_board: 掲示板作成
+    bookmark_index: ブックマーク一覧
+    profile: プロフィール
+  activerecord:
+    attributes:
+      task:
+        title: タイトル
+        memo: メモ
+        estimated_time: 見積時間
+        is_done: 状態
+        recurrence_interval: 繰り返し間隔
+        priority_level: 優先度
+        user: ユーザー
+        parent_task: 親タスク
+        position: 並び順
+        is_done_values:
+          not_started: 未着手
+          closed: 完了

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  resources :tasks
   if Rails.env.development?
     mount LetterOpenerWeb::Engine, at: "/letter_opener"
   end

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -1,0 +1,22 @@
+const defaultTheme = require('tailwindcss/defaultTheme')
+
+module.exports = {
+  content: [
+    './public/*.html',
+    './app/helpers/**/*.rb',
+    './app/javascript/**/*.js',
+    './app/views/**/*.{erb,haml,html,slim}'
+  ],
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: ['Inter var', ...defaultTheme.fontFamily.sans],
+      },
+    },
+  },
+  plugins: [
+    // require('@tailwindcss/forms'),
+    // require('@tailwindcss/typography'),
+    // require('@tailwindcss/container-queries'),
+  ]
+}

--- a/db/migrate/20250614012229_create_tasks.rb
+++ b/db/migrate/20250614012229_create_tasks.rb
@@ -1,0 +1,17 @@
+class CreateTasks < ActiveRecord::Migration[7.2]
+  def change
+    create_table :tasks do |t|
+      t.string :title
+      t.text :memo
+      t.integer :estimated_time
+      t.integer :is_done
+      t.string :recurrence_interval
+      t.integer :priority_level
+      t.integer :user_id
+      t.integer :parent_task_id
+      t.integer :position
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,23 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_10_041333) do
+ActiveRecord::Schema[7.2].define(version: 2025_06_14_012229) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension "pg_catalog.plpgsql"
+  enable_extension "plpgsql"
+
+  create_table "tasks", force: :cascade do |t|
+    t.string "title"
+    t.text "memo"
+    t.integer "estimated_time"
+    t.integer "is_done"
+    t.string "recurrence_interval"
+    t.integer "priority_level"
+    t.integer "user_id"
+    t.integer "parent_task_id"
+    t.integer "position"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,9 +1,14 @@
-# This file should ensure the existence of records required to run the application in every environment (production,
-# development, test). The code here should be idempotent so that it can be executed at any point in every environment.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Example:
-#
-#   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
-#     MovieGenre.find_or_create_by!(name: genre_name)
-#   end
+puts "🌱 Seeding tasks..."
+
+user = User.first || User.create!(email: "test@example.com", password: "password")
+
+puts "Creating task 1"
+Task.create!(title: "買い物に行く", user: user, is_done: :not_started)
+
+puts "Creating task 2"
+Task.create!(title: "レポートを書く", user: user, is_done: :not_started)
+
+puts "Creating task 3"
+Task.create!(title: "本を読む", user: user, is_done: :closed)
+
+puts "✅ Done!"

--- a/test/controllers/tasks_controller_test.rb
+++ b/test/controllers/tasks_controller_test.rb
@@ -1,0 +1,48 @@
+require "test_helper"
+
+class TasksControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @task = tasks(:one)
+  end
+
+  test "should get index" do
+    get tasks_url
+    assert_response :success
+  end
+
+  test "should get new" do
+    get new_task_url
+    assert_response :success
+  end
+
+  test "should create task" do
+    assert_difference("Task.count") do
+      post tasks_url, params: { task: { estimated_time: @task.estimated_time, is_done: @task.is_done, memo: @task.memo, parent_task_id: @task.parent_task_id, position: @task.position, priority_level: @task.priority_level, recurrence_interval: @task.recurrence_interval, title: @task.title, user_id: @task.user_id } }
+    end
+
+    assert_redirected_to task_url(Task.last)
+  end
+
+  test "should show task" do
+    get task_url(@task)
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get edit_task_url(@task)
+    assert_response :success
+  end
+
+  test "should update task" do
+    patch task_url(@task), params: { task: { estimated_time: @task.estimated_time, is_done: @task.is_done, memo: @task.memo, parent_task_id: @task.parent_task_id, position: @task.position, priority_level: @task.priority_level, recurrence_interval: @task.recurrence_interval, title: @task.title, user_id: @task.user_id } }
+    assert_redirected_to task_url(@task)
+  end
+
+  test "should destroy task" do
+    assert_difference("Task.count", -1) do
+      delete task_url(@task)
+    end
+
+    assert_redirected_to tasks_url
+  end
+end

--- a/test/fixtures/tasks.yml
+++ b/test/fixtures/tasks.yml
@@ -1,0 +1,23 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  title: MyString
+  memo: MyText
+  estimated_time: 1
+  is_done: 1
+  recurrence_interval: MyString
+  priority_level: 1
+  user_id: 1
+  parent_task_id: 1
+  position: 1
+
+two:
+  title: MyString
+  memo: MyText
+  estimated_time: 1
+  is_done: 1
+  recurrence_interval: MyString
+  priority_level: 1
+  user_id: 1
+  parent_task_id: 1
+  position: 1

--- a/test/models/task_test.rb
+++ b/test/models/task_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class TaskTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/system/tasks_test.rb
+++ b/test/system/tasks_test.rb
@@ -1,0 +1,57 @@
+require "application_system_test_case"
+
+class TasksTest < ApplicationSystemTestCase
+  setup do
+    @task = tasks(:one)
+  end
+
+  test "visiting the index" do
+    visit tasks_url
+    assert_selector "h1", text: "Tasks"
+  end
+
+  test "should create task" do
+    visit tasks_url
+    click_on "New task"
+
+    fill_in "Estimated time", with: @task.estimated_time
+    fill_in "Is done", with: @task.is_done
+    fill_in "Memo", with: @task.memo
+    fill_in "Parent task", with: @task.parent_task_id
+    fill_in "Position", with: @task.position
+    fill_in "Priority level", with: @task.priority_level
+    fill_in "Recurrence interval", with: @task.recurrence_interval
+    fill_in "Title", with: @task.title
+    fill_in "User", with: @task.user_id
+    click_on "Create Task"
+
+    assert_text "Task was successfully created"
+    click_on "Back"
+  end
+
+  test "should update Task" do
+    visit task_url(@task)
+    click_on "Edit this task", match: :first
+
+    fill_in "Estimated time", with: @task.estimated_time
+    fill_in "Is done", with: @task.is_done
+    fill_in "Memo", with: @task.memo
+    fill_in "Parent task", with: @task.parent_task_id
+    fill_in "Position", with: @task.position
+    fill_in "Priority level", with: @task.priority_level
+    fill_in "Recurrence interval", with: @task.recurrence_interval
+    fill_in "Title", with: @task.title
+    fill_in "User", with: @task.user_id
+    click_on "Update Task"
+
+    assert_text "Task was successfully updated"
+    click_on "Back"
+  end
+
+  test "should destroy Task" do
+    visit task_url(@task)
+    click_on "Destroy this task", match: :first
+
+    assert_text "Task was successfully destroyed"
+  end
+end


### PR DESCRIPTION
## 概要
- タスクの登録・表示・編集・削除機能を実装
- deviseによるユーザー認証後にのみ操作可能
- Taskモデルにenumを導入し、状態の日本語表示に対応
- バリデーションとエラーメッセージの日本語化
- Tailwindを使って簡単なスタイルを適用

## 関連Issue
#17